### PR TITLE
chore: added type for `useState`

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -16,7 +16,7 @@ async function verifyToken() {
 }
 
 export default function DashboardPage() {
-  const [verifyResult, setVerifyResult] = useState();
+  const [verifyResult, setVerifyResult] = useState<any>(null);
   const router = useRouter();
   const {
     ready,


### PR DESCRIPTION
`useState` was missing a type. added it to avoid issues with inference and autocomplete.